### PR TITLE
style: :lipstick: update corner radius for ui components to 8dp for consistency

### DIFF
--- a/.kotlin/errors/errors-1764156516643.log
+++ b/.kotlin/errors/errors-1764156516643.log
@@ -1,0 +1,4 @@
+kotlin version: 2.0.21
+error message: The daemon has terminated unexpectedly on startup attempt #1 with error code: 0. The daemon process output:
+    1. Kotlin compile daemon is ready
+

--- a/app/src/main/java/com/diiage/edusec/ui/core/components/ChallengeCard.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/core/components/ChallengeCard.kt
@@ -74,7 +74,7 @@ fun ChallengeCard(
     }
 
     Card(
-        shape = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(8.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.primary
         ),

--- a/app/src/main/java/com/diiage/edusec/ui/core/components/GroupItem.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/core/components/GroupItem.kt
@@ -38,7 +38,7 @@ fun GroupItem(
         modifier = Modifier
             .fillMaxWidth()
             .padding(8.dp)
-            .clip(RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(8.dp))
             .background(BlueDiiage)
             .clickable { onClick() }
             .padding(horizontal = 16.dp, vertical = 12.dp)

--- a/app/src/main/java/com/diiage/edusec/ui/core/components/input/PrimaryButton.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/core/components/input/PrimaryButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -86,7 +87,8 @@ fun PrimaryButton(
             disabledContainerColor = disabledContainerColor,
             disabledContentColor = disabledContentColor
         ),
-        enabled = enabled && !isLoading
+        enabled = enabled && !isLoading,
+        shape = RoundedCornerShape(8.dp)
     ) {
         if (isLoading) {
             CircularProgressIndicator(

--- a/app/src/main/java/com/diiage/edusec/ui/core/components/input/ThemeSwitcher.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/core/components/input/ThemeSwitcher.kt
@@ -52,7 +52,7 @@ fun ThemeSwitcher(
         // Dropdown trigger
         Surface(
             modifier = Modifier
-                .clip(CircleShape)
+                .clip(RoundedCornerShape(8.dp))
                 .clickable { expanded = true },
             color = MaterialTheme.colorScheme.primary
         ) {
@@ -96,7 +96,7 @@ fun ThemeSwitcher(
             onDismissRequest = { expanded = false },
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.primary)
-                .clip(RoundedCornerShape(12.dp))
+                .clip(RoundedCornerShape(8.dp))
         ) {
             // Light theme option
             DropdownMenuItem(

--- a/app/src/main/java/com/diiage/edusec/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/screens/settings/SettingsScreen.kt
@@ -67,17 +67,17 @@ private fun Content(
                 Spacer(modifier = Modifier.height(24.dp))
 
                 // Accessibility Setting
-                SettingRow(
-                    title = "Accessibilité :",
-                    content = {
-                        PrimarySecondaryToggle(
-                            isPrimarySelected = state.isAccessibilityMode,
-                            onToggle = { enabled ->
-                                handleAction(SettingsContracts.UiAction.AccessibilityModeToggled(enabled))
-                            }
-                        )
-                    }
-                )
+                //SettingRow(
+                    //title = "Accessibilité :",
+                    //content = {
+                        //PrimarySecondaryToggle(
+                            //isPrimarySelected = state.isAccessibilityMode,
+                            //onToggle = { enabled ->
+                                //handleAction(SettingsContracts.UiAction.AccessibilityModeToggled(enabled))
+                            //}
+                        //)
+                    //}
+                //)
             }
         }
     }


### PR DESCRIPTION
This pull request focuses on improving UI consistency by standardizing the corner radius of various components across the app. Most components previously used a 12dp or circular shape for their corners, which have now been changed to a uniform 8dp rounded corner. Additionally, the accessibility setting toggle in the settings screen has been commented out, possibly for future revision or removal.

**UI Consistency Improvements:**

* Changed the corner radius of `ChallengeCard`, `GroupItem`, `PrimaryButton`, and dropdown menus in `ThemeSwitcher` to use `RoundedCornerShape(8.dp)` instead of `RoundedCornerShape(12.dp)` or `CircleShape` for a more unified appearance. [[1]](diffhunk://#diff-cd082ac41b93912d29416ab9a6228cbe4f91c787adc27d07ffaff4870ac752bdL77-R77) [[2]](diffhunk://#diff-2b936f6f4c31fbce5230ccc0b39b465ea9641748be49b9dbe6c3de631a8d38c6L41-R41) [[3]](diffhunk://#diff-bec17903adf05aa37dd8de366aea22e457776902b70b2f9a2534ff3b116376acL89-R91) [[4]](diffhunk://#diff-480bf2e43d3c5484c124214e90934fc46e71f2c1471b475339d98600b6a244b6L55-R55) [[5]](diffhunk://#diff-480bf2e43d3c5484c124214e90934fc46e71f2c1471b475339d98600b6a244b6L99-R99)
* Added missing import for `RoundedCornerShape` in `PrimaryButton.kt` to support the new shape usage.

**Settings Screen Update:**

* Commented out the accessibility setting toggle (`SettingRow` with `PrimarySecondaryToggle`) in `SettingsScreen.kt`, possibly indicating a temporary removal or upcoming changes to accessibility features.