### PR TITLE
feat(quiz): correct pointsEarned calculation in QuizResultViewModel

### DIFF
--- a/app/src/main/java/com/diiage/edusec/ui/screens/challenges/quiz/quizResult/QuizResultViewModel.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/screens/challenges/quiz/quizResult/QuizResultViewModel.kt
@@ -22,7 +22,7 @@ class QuizResultViewModel : ViewModel() {
             it.copy(
                 score = score,
                 total = total,
-                pointsEarned = score * 10
+                pointsEarned = score
             )
         }
     }


### PR DESCRIPTION
This pull request includes a minor update to the calculation of points earned in the `QuizResultViewModel`. The logic now sets `pointsEarned` equal to the raw score, rather than multiplying the score by 10.

- Updated the calculation of `pointsEarned` in `QuizResultViewModel` to use the raw score instead of scaling it by 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the quiz scoring calculation to reflect corrected point values earned upon completing quizzes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->