### PR TITLE
refactor: remove unused button and spacer from HomeScreen

### DIFF
--- a/app/src/main/java/com/diiage/edusec/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/diiage/edusec/ui/screens/home/HomeScreen.kt
@@ -47,15 +47,6 @@ fun HomeScreen(navController: NavController) {
                     onThemeChanged = { themeUpdateTrigger++ }
                 )
 
-                ExtraLargeSpacer()
-
-                PrimaryButton(
-                    onClick = {
-                        navController.navigate("components_test")
-                    },
-                    text = "Tester les Composants"
-                )
-
                 MediumSpacer()
 
                 PrimaryButton(


### PR DESCRIPTION
This pull request makes a small change to the `HomeScreen` UI by removing the "Tester les Composants" button and its surrounding spacer. This simplifies the screen and removes the navigation option to the components test page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the test components button from the home screen interface, streamlining the user experience and reducing unnecessary navigation paths.
  * Adjusted spacing on the home screen layout for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->